### PR TITLE
Add EKS overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ To deploy on GKE, run:
 kustomize build --enable-helm overlays/gke | kubectl apply -f -
 ```
 
+To deploy on **EKS**, run:
+```
+kustomize build --enable-helm overlays/eks | kubectl apply -f -
+```
+
 
 ## SQS
 

--- a/overlays/eks/application.yaml
+++ b/overlays/eks/application.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: default-apps
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: overlays/eks/apps
+    repoURL: https://github.com/metalbear-co/playground
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false

--- a/overlays/eks/apps/ip-visit-counter-patch.yaml
+++ b/overlays/eks/apps/ip-visit-counter-patch.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ip-visit-counter
+  namespace: argocd
+spec:
+  source:
+    kustomize:
+      patches:
+        - target:
+            kind: Deployment
+            name: ip-visit-sqs-consumer
+          patch: |-
+            - op: add
+              path: "/spec/template/spec/containers/0/env/-"
+              value:
+                name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-credentials
+                    key: AWS_ACCESS_KEY_ID
+            - op: add
+              path: "/spec/template/spec/containers/0/env/-"
+              value:
+                name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-credentials
+                    key: AWS_SECRET_ACCESS_KEY
+            - op: add
+              path: "/spec/template/spec/containers/0/env/-"
+              value:
+                name: AWS_DEFAULT_REGION
+                value: "us-east-2"

--- a/overlays/eks/apps/ip-visit-sqs-consumer-patch.yaml
+++ b/overlays/eks/apps/ip-visit-sqs-consumer-patch.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ip-visit-sqs-consumer
+  namespace: argocd
+spec:
+  source:
+    kustomize:
+      patches:
+        - target:
+            kind: Deployment
+            name: ip-visit-sqs-consumer
+          patch: |-
+            - op: add
+              path: "/spec/template/spec/containers/0/env/-"
+              value:
+                name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-credentials
+                    key: AWS_ACCESS_KEY_ID
+            - op: add
+              path: "/spec/template/spec/containers/0/env/-"
+              value:
+                name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-credentials
+                    key: AWS_SECRET_ACCESS_KEY
+            - op: add
+              path: "/spec/template/spec/containers/0/env/-"
+              value:
+                name: AWS_DEFAULT_REGION
+                value: "us-east-2"

--- a/overlays/eks/apps/kustomization.yaml
+++ b/overlays/eks/apps/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/apps
+patches:
+  - path: ip-visit-counter-patch.yaml
+  - path: ip-visit-sqs-consumer-patch.yaml

--- a/overlays/eks/argo-rollouts/kustomization.yaml
+++ b/overlays/eks/argo-rollouts/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argo-rollouts
+resources:
+  - https://github.com/argoproj/argo-rollouts/manifests/cluster-install

--- a/overlays/eks/argocd/kustomization.yaml
+++ b/overlays/eks/argocd/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+resources:
+  - https://github.com/argoproj/argo-cd/manifests/cluster-install

--- a/overlays/eks/ingress.yaml
+++ b/overlays/eks/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: playground-metalbear-dev-ingress
+spec:
+  ingressClassName: alb
+  defaultBackend:
+    service:
+      name: ip-visit-frontend
+      port:
+        number: 3000
+  rules:
+  - http:
+      paths:
+      - path: /count
+        pathType: Prefix
+        backend:
+          service:
+            name: ip-visit-counter
+            port:
+              number: 80
+      - path: /health
+        pathType: Prefix
+        backend:
+          service:
+            name: ip-visit-counter
+            port:
+              number: 80

--- a/overlays/eks/kustomization.yaml
+++ b/overlays/eks/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - argocd
+  - argo-rollouts
+  - application.yaml
+  - ingress.yaml
+  - namespace.yaml
+  - secret.yaml

--- a/overlays/eks/namespace.yaml
+++ b/overlays/eks/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo-rollouts

--- a/overlays/eks/secret.yaml
+++ b/overlays/eks/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-credentials
+  type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: YOUR_ACCESS_KEY_ID
+  AWS_SECRET_ACCESS_KEY: YOUR_SECRET_ACCESS_KEY


### PR DESCRIPTION
## Summary
- add an overlay for Amazon EKS with its own ingress and patches
- document the new overlay in the README

## Testing
- `go vet ./...` *(fails: no route to host)*