### PR TITLE
feat: split ingress per app namespace

### DIFF
--- a/overlays/gke/ip-visit/ingress.yaml
+++ b/overlays/gke/ip-visit/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: playground-metalbear-dev-ingress
+  namespace: ip-visit-counter
   annotations:
     networking.gke.io/managed-certificates: playground-metalbear-dev-cert
     kubernetes.io/ingress.class: "gce"
@@ -21,24 +22,10 @@ spec:
             name: ip-visit-counter
             port:
               number: 80
-      - path: /visualization/api
-        pathType: Prefix
-        backend:
-          service:
-            name: visualization-backend
-            port:
-              number: 80
-      - path: /visualization
-        pathType: Prefix
-        backend:
-          service:
-            name: visualization-frontend
-            port:
-              number: 80
       - path: /health
         pathType: Prefix
         backend:
           service:
             name: ip-visit-counter
-            port: 
+            port:
               number: 80

--- a/overlays/gke/ip-visit/kustomization.yaml
+++ b/overlays/gke/ip-visit/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../ip-visit-application.yaml
+  - ingress.yaml
 
 patches:
   - path: patches/counter-patch.yaml

--- a/overlays/gke/kustomization.yaml
+++ b/overlays/gke/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
   - argo-rollouts
   - shared-infra-application.yaml
   - ip-visit
+  - visualization
   - visualization-application.yaml
-  - ingress.yaml
   - namespace.yaml
   - certificate.yaml
   - secret.yaml

--- a/overlays/gke/visualization/ingress.yaml
+++ b/overlays/gke/visualization/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: playground-metalbear-dev-visualization-ingress
+  namespace: visualization
+  annotations:
+    networking.gke.io/managed-certificates: playground-metalbear-dev-cert
+    kubernetes.io/ingress.class: "gce"
+    ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /visualization/api
+        pathType: Prefix
+        backend:
+          service:
+            name: visualization-backend
+            port:
+              number: 80
+      - path: /visualization
+        pathType: Prefix
+        backend:
+          service:
+            name: visualization-frontend
+            port:
+              number: 80

--- a/overlays/gke/visualization/kustomization.yaml
+++ b/overlays/gke/visualization/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../manifests/visualization
+  - ingress.yaml


### PR DESCRIPTION
## Summary
Split the single ingress into per-app ingresses to comply with Kubernetes constraint that Ingress can only route to Services in the same namespace.

## Changes
- Create `overlays/gke/ip-visit/ingress.yaml` for `ip-visit-counter` namespace
  - Routes `/` (defaultBackend), `/count`, `/health`
- Create `overlays/gke/visualization/ingress.yaml` for `visualization` namespace
  - Routes `/visualization` and `/visualization/api` with rewrite annotation
- Create `overlays/gke/visualization/kustomization.yaml`
- Update `overlays/gke/ip-visit/kustomization.yaml` to include ingress
- Update `overlays/gke/kustomization.yaml` to use visualization overlay
- Remove `overlays/gke/ingress.yaml` (replaced by per-app ingresses)

## Stacking
This PR is stacked on PR 2 (`refactor/manifests-structure`). 
- **Base branch**: `refactor/manifests-structure` (will rebase to `main` after PR 2 merges)
- **Status**: Draft - waiting for PR 2 to merge

## Testing
- [ ] `kubectl kustomize overlays/gke/ip-visit` builds successfully
- [ ] `kubectl kustomize overlays/gke/visualization` builds successfully
- [ ] `kubectl kustomize overlays/gke` builds successfully
- [ ] Ingress resources have correct namespace in metadata
- [ ] Service references match service names in their namespaces