### PR TITLE
feat(infra): point apps at shared infra namespace (PR 2/3)

### DIFF
--- a/manifests/ip-visit/base/app/consumer-kafka/deployment.yaml
+++ b/manifests/ip-visit/base/app/consumer-kafka/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         - name: PORT
           value: "80"
         - name: KAFKAADDRESS
-          value: kafka:9092
+          value: kafka.infra.svc.cluster.local:9092
         - name: KAFKATOPIC
           value: ip-visit
         - name: KAFKACONSUMERGROUP

--- a/manifests/ip-visit/base/app/counter/deployment.yaml
+++ b/manifests/ip-visit/base/app/counter/deployment.yaml
@@ -17,11 +17,11 @@ spec:
         - name: PORT
           value: "80"
         - name: REDISADDRESS
-          value: redis-main:6379
+          value: redis-main.infra.svc.cluster.local:6379
         - name: RESPONSEFILE
           value: /app/response.txt
         - name: KAFKAADDRESS
-          value: kafka:9092
+          value: kafka.infra.svc.cluster.local:9092
         - name: KAFKATOPIC
           value: ip-visit
         - name: IPINFOADDRESS

--- a/manifests/shop-mirrord/kafka-client-config.yaml
+++ b/manifests/shop-mirrord/kafka-client-config.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   properties:
     - name: bootstrap.servers
-      value: kafka.shop.svc.cluster.local:9092
+      value: kafka.infra.svc.cluster.local:9092
     - name: client.id
       value: mirrord-operator-shop

--- a/manifests/shop/base/app/delivery-service/deployment.yaml
+++ b/manifests/shop/base/app/delivery-service/deployment.yaml
@@ -19,13 +19,13 @@ spec:
             - name: PORT
               value: "80"
             - name: KAFKA_ADDRESS
-              value: "kafka:9092"
+              value: "kafka.infra.svc.cluster.local:9092"
             - name: KAFKA_TOPIC
               value: "orders"
             - name: KAFKA_CONSUMER_GROUP
               value: "delivery-service"
             - name: DATABASE_URL
-              value: "postgresql://postgres:postgres@postgres:5432/deliveries"
+              value: "postgresql://postgres:postgres@postgres.infra.svc.cluster.local:5432/deliveries"
           ports:
             - containerPort: 80
               protocol: TCP

--- a/manifests/shop/base/app/inventory-service/deployment.yaml
+++ b/manifests/shop/base/app/inventory-service/deployment.yaml
@@ -19,7 +19,7 @@ spec:
             - name: PORT
               value: "80"
             - name: DATABASE_URL
-              value: "postgresql://postgres:postgres@postgres:5432/inventory"
+              value: "postgresql://postgres:postgres@postgres.infra.svc.cluster.local:5432/inventory"
           ports:
             - containerPort: 80
               protocol: TCP

--- a/manifests/shop/base/app/order-service/deployment.yaml
+++ b/manifests/shop/base/app/order-service/deployment.yaml
@@ -19,13 +19,13 @@ spec:
             - name: PORT
               value: "80"
             - name: DATABASE_URL
-              value: "postgresql://postgres:postgres@postgres:5432/orders"
+              value: "postgresql://postgres:postgres@postgres.infra.svc.cluster.local:5432/orders"
             - name: INVENTORY_SERVICE_URL
               value: "http://inventory-service:80"
             - name: PAYMENT_SERVICE_URL
               value: "http://payment-service:80"
             - name: KAFKA_ADDRESS
-              value: "kafka:9092"
+              value: "kafka.infra.svc.cluster.local:9092"
             - name: KAFKA_TOPIC
               value: "orders"
           ports:


### PR DESCRIPTION
- ip-visit: counter and consumer-kafka use redis-main.infra.svc.cluster.local and kafka.infra.svc.cluster.local
- shop: inventory, order, delivery use postgres.infra.svc.cluster.local and kafka.infra.svc.cluster.local
- shop-mirrord: Kafka client config bootstrap.servers → infra

Per-app infra (base/infra) left in place for PR 3 removal; no disruption.